### PR TITLE
Catch and warn about division by zero at runtime

### DIFF
--- a/mugo.go
+++ b/mugo.go
@@ -608,6 +608,14 @@ func genProgramStart() {
 	print("pop rbp\n")
 	print("ret 24\n")
 	print("\n")
+
+	print("_divideByZero:\n")
+	print("push qword 15\n") // len("divide by zero\n")
+	print("push _strDivideByZero\n")
+	print("call log\n")
+	print("push qword 1\n")
+	print("call exit\n")
+	print("\n")
 }
 
 func genConst(name string, value int) {
@@ -866,6 +874,7 @@ func genDataSections() {
 	print("\n")
 	print("section .data\n")
 	print("_strOutOfMem: db `out of memory\\n`\n")
+	print("_strDivideByZero: db `divide by zero\\n`\n")
 
 	// String constants
 	i := 0
@@ -945,6 +954,8 @@ func genBinaryInt(op int) int {
 	} else if op == tTimes {
 		print("imul rbx\n")
 	} else if op == tDivide {
+		print("cmp rbx, 0\n")
+		print("jz _divideByZero\n")
 		print("cqo\n")
 		print("idiv rbx\n")
 	} else if op == tModulo {


### PR DESCRIPTION
Consider the following example:

         package main
         func main() {

                number := 1 / 0

                if number == 17 {
                        print("Weird\n")
                }
         }

Without any changes this could be built, and executed, like so:

         $ go run . < examples/divide.go  > build/divide.asm
         $ nasm -felf64 -o build/divide.o build/divide.asm
         $ ld -o build/divide build/divide.o
         $ ./build/divide
         Floating point exception

The floatin-point exception here comes from the attempted divison
by zero.  I did consider catching this at code-generation time, however
that would only work for the case of `foo/0`, rather than:

        a := 3
        b := 0
        c := a / b

So this pull-request adds an explicit handler to print a fatal error
and terminate, and compares the divisor with zero - jumping to that
error-handler if it is found.